### PR TITLE
Option to not start Spotifiy at start

### DIFF
--- a/MuteSpotifyAds/AppDelegate.swift
+++ b/MuteSpotifyAds/AppDelegate.swift
@@ -13,6 +13,7 @@ import Foundation
 class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDelegate {
     let endlessPrivateSessionKey = "EndlessPrivateSession"
     let restartToSkipAdsKey = "RestartToSkipAds"
+    let startSpotifyAtAppStartKey = "StartSpotifyWhenMSAStarts"
     let notificationsKey = "Notifications"
     let songLogPathKey = "SongLogPath"
     
@@ -20,6 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     @IBOutlet weak var titleMenuItem: NSMenuItem!
     @IBOutlet weak var endlessPrivateSessionCheckbox: NSMenuItem!
     @IBOutlet weak var restartToSkipAdsCheckbox: NSMenuItem!
+    @IBOutlet weak var startSpotifyAtAppStartCheckbox: NSMenuItem!
     @IBOutlet weak var notificationsCheckbox: NSMenuItem!
     @IBOutlet weak var songLogCheckbox: NSMenuItem!
     
@@ -83,6 +85,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         UserDefaults.standard.set(notificationsEnabled, forKey: notificationsKey)
     }
     
+    @IBAction func toggleSpotifyStartATS(_ sender: NSMenuItem) {
+        if spotifyManager!.startSpotifyATS {
+            spotifyManager?.startSpotifyATS = false
+            sender.state = .off
+        } else {
+            spotifyManager?.startSpotifyATS = true
+            sender.state = .on
+        }
+        UserDefaults.standard.set(spotifyManager?.startSpotifyATS, forKey: startSpotifyAtAppStartKey)
+    }
+    
     @IBAction func toggleSongLog(_ sender: NSMenuItem) {
         if spotifyManager?.songLogPath != nil {
             spotifyManager?.songLogPath = nil
@@ -135,6 +148,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         if UserDefaults.standard.bool(forKey: restartToSkipAdsKey) {
             spotifyManager?.restartToSkipAdsEnabled = true
             restartToSkipAdsCheckbox.state = .on
+        }
+        
+        if UserDefaults.standard.bool(forKey: startSpotifyAtAppStartKey) {
+            spotifyManager?.startSpotifyATS = true
+            startSpotifyAtAppStartCheckbox.state = .on
+        } else {
+            spotifyManager?.startSpotifyATS = false
+            startSpotifyAtAppStartCheckbox.state = .off
         }
         
         if UserDefaults.standard.object(forKey: notificationsKey) == nil {

--- a/MuteSpotifyAds/AppDelegate.swift
+++ b/MuteSpotifyAds/AppDelegate.swift
@@ -13,7 +13,7 @@ import Foundation
 class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDelegate {
     let endlessPrivateSessionKey = "EndlessPrivateSession"
     let restartToSkipAdsKey = "RestartToSkipAds"
-    let startSpotifyAtAppStartKey = "StartSpotifyWhenMSAStarts"
+    let startSpotifyKey = "StartSpotify"
     let notificationsKey = "Notifications"
     let songLogPathKey = "SongLogPath"
     
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     @IBOutlet weak var titleMenuItem: NSMenuItem!
     @IBOutlet weak var endlessPrivateSessionCheckbox: NSMenuItem!
     @IBOutlet weak var restartToSkipAdsCheckbox: NSMenuItem!
-    @IBOutlet weak var startSpotifyAtAppStartCheckbox: NSMenuItem!
+    @IBOutlet weak var startSpotifyCheckbox: NSMenuItem!
     @IBOutlet weak var notificationsCheckbox: NSMenuItem!
     @IBOutlet weak var songLogCheckbox: NSMenuItem!
     
@@ -85,15 +85,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         UserDefaults.standard.set(notificationsEnabled, forKey: notificationsKey)
     }
     
-    @IBAction func toggleSpotifyStartATS(_ sender: NSMenuItem) {
-        if spotifyManager!.startSpotifyATS {
-            spotifyManager?.startSpotifyATS = false
+    @IBAction func toggleSpotifyStart(_ sender: NSMenuItem) {
+        if spotifyManager!.startSpotify {
+            spotifyManager?.startSpotify = false
             sender.state = .off
         } else {
-            spotifyManager?.startSpotifyATS = true
+            spotifyManager?.startSpotify = true
             sender.state = .on
         }
-        UserDefaults.standard.set(spotifyManager?.startSpotifyATS, forKey: startSpotifyAtAppStartKey)
+        UserDefaults.standard.set(spotifyManager?.startSpotify, forKey: startSpotifyKey)
     }
     
     @IBAction func toggleSongLog(_ sender: NSMenuItem) {
@@ -150,12 +150,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             restartToSkipAdsCheckbox.state = .on
         }
         
-        if UserDefaults.standard.bool(forKey: startSpotifyAtAppStartKey) {
-            spotifyManager?.startSpotifyATS = true
-            startSpotifyAtAppStartCheckbox.state = .on
+        if UserDefaults.standard.bool(forKey: startSpotifyKey) {
+            spotifyManager?.startSpotify = true
+            startSpotifyCheckbox.state = .on
         } else {
-            spotifyManager?.startSpotifyATS = false
-            startSpotifyAtAppStartCheckbox.state = .off
+            spotifyManager?.startSpotify = false
+            startSpotifyCheckbox.state = .off
         }
         
         if UserDefaults.standard.object(forKey: notificationsKey) == nil {

--- a/MuteSpotifyAds/Base.lproj/MainMenu.xib
+++ b/MuteSpotifyAds/Base.lproj/MainMenu.xib
@@ -18,7 +18,7 @@
                 <outlet property="notificationsCheckbox" destination="xcw-JU-8Ai" id="VMH-h2-Gmq"/>
                 <outlet property="restartToSkipAdsCheckbox" destination="7pt-Ak-HDD" id="DD7-3v-iN8"/>
                 <outlet property="songLogCheckbox" destination="GPc-bM-QPt" id="Cvp-2p-C95"/>
-                <outlet property="startSpotifyAtAppStartCheckbox" destination="Zxc-BN-6PQ" id="jXN-Jz-GQX"/>
+                <outlet property="startSpotifyCheckbox" destination="Zxc-BN-6PQ" id="aSJ-67-53J"/>
                 <outlet property="statusMenu" destination="KUr-cl-g3N" id="quZ-j6-rXq"/>
                 <outlet property="titleMenuItem" destination="Qme-N6-cSD" id="InN-nV-s8I"/>
             </connections>
@@ -48,7 +48,7 @@
                 <menuItem title="◎ Start Spotify with MSA" id="Zxc-BN-6PQ">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="toggleSpotifyStartATS:" target="Voe-Tx-rLC" id="CEp-kc-9Ka"/>
+                        <action selector="toggleSpotifyStart:" target="Voe-Tx-rLC" id="LId-yN-U4o"/>
                     </connections>
                 </menuItem>
                 <menuItem title="➤  Notifications" id="xcw-JU-8Ai">

--- a/MuteSpotifyAds/Base.lproj/MainMenu.xib
+++ b/MuteSpotifyAds/Base.lproj/MainMenu.xib
@@ -18,6 +18,7 @@
                 <outlet property="notificationsCheckbox" destination="xcw-JU-8Ai" id="VMH-h2-Gmq"/>
                 <outlet property="restartToSkipAdsCheckbox" destination="7pt-Ak-HDD" id="DD7-3v-iN8"/>
                 <outlet property="songLogCheckbox" destination="GPc-bM-QPt" id="Cvp-2p-C95"/>
+                <outlet property="startSpotifyAtAppStartCheckbox" destination="Zxc-BN-6PQ" id="jXN-Jz-GQX"/>
                 <outlet property="statusMenu" destination="KUr-cl-g3N" id="quZ-j6-rXq"/>
                 <outlet property="titleMenuItem" destination="Qme-N6-cSD" id="InN-nV-s8I"/>
             </connections>
@@ -42,6 +43,12 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="toggleRestartToSkipAds:" target="Voe-Tx-rLC" id="FrK-V2-X4I"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="◎ Start Spotify with MSA" id="Zxc-BN-6PQ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleSpotifyStartATS:" target="Voe-Tx-rLC" id="CEp-kc-9Ka"/>
                     </connections>
                 </menuItem>
                 <menuItem title="➤  Notifications" id="xcw-JU-8Ai">
@@ -83,6 +90,7 @@
                     </connections>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="196" y="144"/>
         </menu>
     </objects>
 </document>

--- a/MuteSpotifyAds/SpotifyManager.swift
+++ b/MuteSpotifyAds/SpotifyManager.swift
@@ -8,21 +8,6 @@
 
 import Cocoa
 
-func runCommand(launchPath: String, arguments: [String]) -> String
-{
-    let task = Process()
-    task.launchPath = launchPath
-    task.arguments = arguments
-    
-    let pipe = Pipe()
-    task.standardOutput = pipe
-    task.launch()
-    
-    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-    let output = String(data: data, encoding: String.Encoding.utf8)!
-    return output
-}
-
 class SpotifyManager: NSObject {
     
     static let appleScriptSpotifyPrefix = "tell application \"Spotify\" to "

--- a/MuteSpotifyAds/SpotifyManager.swift
+++ b/MuteSpotifyAds/SpotifyManager.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-func shell(launchPath: String, arguments: [String]) -> String
+func runCommand(launchPath: String, arguments: [String]) -> String
 {
     let task = Process()
     task.launchPath = launchPath
@@ -33,7 +33,7 @@ class SpotifyManager: NSObject {
     var endlessPrivateSessionEnabled = false
     var restartToSkipAdsEnabled = false
     var songLogPath: String? = nil
-    var startSpotifyATS = false
+    var startSpotify = false
     
     /**
      * Volume before mute, between 0 and 100
@@ -65,17 +65,9 @@ class SpotifyManager: NSObject {
             }
         })
         
-        if startSpotifyATS {
+        if startSpotify {
             DispatchQueue.global(qos: .default).async {
                 self.startSpotify(foreground: true)
-                _ = self.trackChanged()
-            }
-        } else {
-            var app: String = ""
-            DispatchQueue.global(qos: .default).async {
-                while !app.contains("Applications/Spotify") {
-                    app = shell(launchPath: "/bin/ps", arguments: ["aux"])
-                }
                 _ = self.trackChanged()
             }
         }


### PR DESCRIPTION
See issue #20 
MuteSpotifyAds waits for Spotify to start.
After Spotify is started MSA tracks songs and blocks ads.
The checkbox to manage this setting doesn't work. 
(@simonmeusel Could you try to debug that?)
